### PR TITLE
:construction_worker: Auto-update coverage badge via CI

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,7 +10,7 @@ categories:
   - title: ":wrench: Fixes & Refactoring"
     labels: [bug, refactoring, bugfix, fix]
   - title: ":package: Build System & CI/CD"
-    labels: [build, ci, testing]
+    labels: [build, ci, testing, github_actions]
   - title: ":boom: Breaking Changes"
     labels: [breaking]
   - title: ":pencil: Documentation"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,24 @@ jobs:
     - name: Run safety checks
       run: |
         make check-safety
+
+    - name: Verify changed coverage badge
+      uses: tj-actions/verify-changed-files@v16
+      id: verify-changed-files
+      with:
+        files: assets/images/coverage.svg
+
+    - name: Commit coverage badge
+      if: steps.verify-changed-files.outputs.files_changed == 'true'
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add assets/images/coverage.svg
+        git commit -m "Updated coverage.svg"
+
+    - name: Push coverage badge
+      if: steps.verify-changed-files.outputs.files_changed == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.github_token }}
+        branch: ${{ github.ref }}


### PR DESCRIPTION
## Description
Update the GH action to automatically update (push) the coverage badge if it has changes.

## Related Issue

n/a

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
