### PR TITLE
Feature: Configure HTTPX timeouts and limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ check-codestyle:
 
 .PHONY: check-typing
 check-typing:
-	poetry run mypy --config-file pyproject.toml ./
+	poetry run mypy --config-file pyproject.toml unparallel
 
 .PHONY: check-safety
 check-safety:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center" markdown="1">
 
-Create Python async web requests in no time with **unparallel**!
+Create async HTTP requests with Python in no time.
 
 [![Build status](https://github.com/RafaelWO/unparallel/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/RafaelWO/unparallel/actions?query=workflow%3Atest)
 ![Coverage Report](https://raw.githubusercontent.com/RafaelWO/unparallel/main/assets/images/coverage.svg)
@@ -18,6 +18,10 @@ Create Python async web requests in no time with **unparallel**!
 [![License](https://img.shields.io/github/license/RafaelWO/unparallel)](https://github.com/RafaelWO/unparallel/blob/main/LICENSE)
 
 </div>
+
+With Unparallel you can easily create thousands of web requests in an efficient way leveraging Python's async capabilities.
+
+Unparallel is built on top of [HTTPX](https://github.com/encode/httpx/) and aims to support its rich set of features.
 
 ## Installation
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,12 +1,1 @@
 ::: unparallel
-    options:
-      show_root_heading: true
-      
-
-::: unparallel.unparallel
-    options:
-      show_root_heading: true
-      members:
-        - sort_by_idx
-        - single_request
-        - request_urls

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,11 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          members_order: source
+          options:
+            show_root_heading: true
+            members_order: source
+            show_root_members_full_path: true
+            separate_signature: true
 markdown_extensions:
   - md_in_html
   - pymdownx.highlight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,6 @@ exclude = '''
 py_version = 38
 line_length = 88
 
-known_typing = ["typing", "types", "typing_extensions", "mypy", "mypy_extensions"]
-sections = ["FUTURE", "TYPING", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 include_trailing_comma = true
 profile = "black"
 multi_line_output = 3

--- a/tests/test_unparallel.py
+++ b/tests/test_unparallel.py
@@ -27,7 +27,7 @@ def test_order_by_idx():
 @pytest.mark.parametrize(
     "url, method, payload",
     [
-        ("http://test.com", "get", "data"),
+        ("http://test.com", "GET", "data"),
         ("http://test.com/foo", "post", "data"),
     ],
 )
@@ -45,7 +45,7 @@ async def test_single_request_fail(status, respx_mock):
     url = "http://test.com/foo"
     respx_mock.get(url).mock(return_value=Response(status))
     session = AsyncClient()
-    result = await single_request(1, session, path=url, method="get")
+    result = await single_request(1, session, path=url, method="GET")
     assert isinstance(result[1], RequestError)
     await session.aclose()
 
@@ -58,7 +58,7 @@ async def test_single_request_timeout(respx_mock):
     start_time = time.time()
     retries = 2
     result = await single_request(
-        1, session, path=url, method="get", max_retries_on_timeout=retries
+        1, session, path=url, method="GET", max_retries_on_timeout=retries
     )
     assert isinstance(result[1], RequestError)
     assert time.time() - start_time > retries
@@ -85,7 +85,7 @@ async def test_up_get(caplog, respx_mock):
             return_value=Response(200, json={key: int(val)})
         )
 
-    results = await up(base_url, paths, "get")
+    results = await up(base_url, paths, "GET")
 
     my_log = next(rec for rec in caplog.records if rec.module == "unparallel")
     assert "Issuing 3 GET request(s)" in my_log.message
@@ -125,7 +125,7 @@ async def test_request_urls_flat(patched_fetch):
 async def test_up_misaligned_paths_and_payloads():
     with pytest.raises(ValueError):
         await up(
-            "http://test.com", paths=["/a", "/b"], method="post", payloads=[1, 2, 3]
+            "http://test.com", paths=["/a", "/b"], method="POST", payloads=[1, 2, 3]
         )
 
 

--- a/tests/test_unparallel.py
+++ b/tests/test_unparallel.py
@@ -27,7 +27,7 @@ def test_order_by_idx():
 @pytest.mark.parametrize(
     "url, method, payload",
     [
-        ("http://test.com", "GET", "data"),
+        ("http://test.com", "get", "data"),
         ("http://test.com/foo", "post", "data"),
     ],
 )

--- a/unparallel/__init__.py
+++ b/unparallel/__init__.py
@@ -1,5 +1,3 @@
-"""Create async web requests in no time."""
-
 from importlib import metadata as importlib_metadata
 
 from .unparallel import RequestError, up

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -7,7 +7,7 @@ import httpx
 from tqdm.asyncio import tqdm as tqdm_async
 
 logger = logging.getLogger(__name__)
-VALID_HTTP_METHODS = ("get", "options", "head", "post", "put", "patch", "delete")
+VALID_HTTP_METHODS = ("GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS")
 
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=10)
 DEFAULT_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
@@ -69,7 +69,7 @@ async def single_request(
             kwargs = {}
             if method in ["post", "put", "patch"]:
                 kwargs["json"] = json
-            response = await getattr(client, method.lower())(path, **kwargs)
+            response = await client.request(method, path, **kwargs)
             response.raise_for_status()
             json_data = response.json()
             return idx, json_data
@@ -170,7 +170,7 @@ async def request_urls(
 async def up(
     base_url: str,
     paths: Union[str, List[str]],
-    method: str = "get",
+    method: str = "GET",
     headers: Optional[Dict[str, Any]] = None,
     payloads: Optional[Any] = None,
     flatten_result: bool = False,
@@ -189,8 +189,8 @@ async def up(
         paths (Union[str, List[str]]): One path or a list of paths, e.g. /foobar/.
             If one path but multiple payloads are supplied, that path is used for all
             requests.
-        method (str): HTTP method to use, e.g. get, post, etc.
-            Defaults to "get".
+        method (str): HTTP method to use - one of ``GET``, ``OPTIONS``, ``HEAD``,
+            ``POST``, ``PUT``, ``PATCH``, or ``DELETE``. Defaults to ``GET``.
         headers (Optional[Dict[str, Any]], optional): A dictionary of headers to use.
             Defaults to None.
         payloads (Optional[Any], optional): A list of JSON payloads (dictionaries) e.g.
@@ -222,7 +222,7 @@ async def up(
         input (paths/payloads).
     """
     # Check if method it valid
-    if method not in VALID_HTTP_METHODS:
+    if method.upper() not in VALID_HTTP_METHODS:
         raise ValueError(
             f"The method '{method}' is not a supported HTTP method. "
             f"Supported methods: {VALID_HTTP_METHODS}"

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -104,8 +104,8 @@ async def request_urls(
     payloads: Optional[Any] = None,
     flatten_result: bool = False,
     max_retries_on_timeout: int = 3,
-    timeouts: httpx.Timeout = DEFAULT_TIMEOUT,
     limits: httpx.Limits = DEFAULT_LIMITS,
+    timeouts: httpx.Timeout = DEFAULT_TIMEOUT,
     progress: bool = True,
 ) -> List[Any]:
     """
@@ -124,8 +124,8 @@ async def request_urls(
             list of lists. This is useful when using paging.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
-        timeouts (httpx.Timeout): The timeout configuration for ``httpx``.
         limits (httpx.Limits): The limits configuration for ``httpx``.
+        timeouts (httpx.Timeout): The timeout configuration for ``httpx``.
         progress: If set to True, progress bar is shown
 
     Returns:
@@ -177,8 +177,8 @@ async def up(
     max_connections: Optional[int] = 100,
     timeout: Optional[int] = 10,
     max_retries_on_timeout: int = 3,
-    timeouts: Optional[httpx.Timeout] = None,
     limits: Optional[httpx.Limits] = None,
+    timeouts: Optional[httpx.Timeout] = None,
     progress: bool = True,
 ) -> List[Any]:
     """Creates async web requests to a URL at the specified path(s) via ``asyncio``
@@ -204,10 +204,10 @@ async def up(
             This is passed into ``httpx.Timeout``.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
-        timeouts (Optional[httpx.Timeout]): The timeout configuration for ``httpx``.
-            If specified, this overrides the ``timeout`` parameter.
         limits (Optional[httpx.Limits]): The limits configuration for ``httpx``.
             If specified, this overrides the ``max_connections`` parameter.
+        timeouts (Optional[httpx.Timeout]): The timeout configuration for ``httpx``.
+            If specified, this overrides the ``timeout`` parameter.
         progress (bool): If set to True, progress bar is shown.
             Defaults to True.
 
@@ -259,6 +259,6 @@ async def up(
         flatten_result=flatten_result,
         max_retries_on_timeout=max_retries_on_timeout,
         progress=progress,
-        timeouts=timeouts,
         limits=limits,
+        timeouts=timeouts,
     )

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -50,10 +50,10 @@ async def single_request(
     """Do a single web request for the given path, HTTP method, and playload.
 
     Args:
-        idx (int): The index of the task (required for sorting afterwards)
-        client (AsyncClient): The httpx client
-        path (str): The path after the base URI
-        method (str): The HTTP method
+        idx (int): The index of the task (required for sorting afterwards).
+        client (AsyncClient): The httpx client.
+        path (str): The path after the base URI.
+        method (str): The HTTP method.
         json (Optional[Any], optional): The JSON payload. Defaults to None.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
@@ -63,13 +63,9 @@ async def single_request(
     """
     trial = 0
     exception: Optional[Exception] = None
-    method = method.lower()
     for trial in range(1, max_retries_on_timeout + 1):
         try:
-            kwargs = {}
-            if method in ["post", "put", "patch"]:
-                kwargs["json"] = json
-            response = await client.request(method, path, **kwargs)
+            response = await client.request(method, path, json=json)
             response.raise_for_status()
             json_data = response.json()
             return idx, json_data


### PR DESCRIPTION
## Description

This PR adds options to `up()` for setting timeouts and limits in HTTPX requests. 

Changes:
* ✨ Add support for setting HTTPX timeouts and limits
* 🔨 Run mypy only in source; remove custom isort order
* 📝 README: Update tag line and short description
* ♻️ Reorder up() args
* ♻️ Default to using uppercase HTTP method names, e.g. 'GET'
* 📝 Update docs (API Reference)

### 💣 Breaking Change!
To be in line with HTTPX's options, the parameter `connection_limit` was renamed to `max_connections` ([same as in HTTPX](https://www.python-httpx.org/advanced/#pool-limit-configuration)).

### Details

New/changed options:
* `max_connections (int)`: The total number of simultaneous TCP connections (former `max_connections`). This is passed into `httpx.Limits`
* `timeout (int)`: The timeout for requests in seconds. This is passed into `httpx.Timeout`.
* `timeouts (Optional[httpx.Timeout])`: The HTTPX timeout configuration. This overrides `timeout`.
* `limits (Optional[httpx.Limits])`: The HTTPX limits configuration. This overrides `max_connections`.

If you don't care about a detailed timeout or limits configuration, you can still use `up()` same as before:

```python
results = await up(base_url, paths)
```

Otherwise, you can use the simplified parameters `max_connections` for setting a connection limit and `timeout` for setting (all) timeouts for requests:


```python
results = await up(base_url, paths, max_connections=10, timeout=60)
# This results in the limits config created via `httpx.Limits(max_connections=10, **default_values)`
# and timeout config created via `httpx.Timeout(60)`
```

For more fine-grained control over limits and timeouts, just specify the HTTPX configs and pass them in:

```python
results = await up(
    base_url, 
    paths, 
    limits=httpx.Limits(max_connections=20, ...), 
    timeouts=httpx.Timeout(connect=5, ...)
)
```

## Related Issue
Implements #86 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
