### PR TITLE
✨ Add support for single payload for multiple paths

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,25 +11,19 @@ theme:
   features:
     - content.code.copy
   palette:
-    # Palette toggle for automatic mode
-    - media: "(prefers-color-scheme)"
-      toggle:
-        icon: material/brightness-auto
-        name: Switch to light mode
-
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default 
       toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
+        icon: octicons/moon-16
+        name: "Switch to dark mode"
 
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
-        icon: material/brightness-4
-        name: Switch to system preference
+        icon: octicons/sun-16
+        name: "Switch to light mode"
 plugins:
   - search
   - mkdocstrings:

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -190,7 +190,9 @@ async def up(
         headers (Optional[Dict[str, Any]], optional): A dictionary of headers to use.
             Defaults to None.
         payloads (Optional[Any], optional): A list of JSON payloads (dictionaries) e.g.
-            for HTTP post requests. Used together with paths. Defaults to None.
+            for HTTP post requests. Used together with paths. If one payload but
+            multiple paths are supplied, that payload is used for all requests.
+            Defaults to None.
         flatten_result (bool): If True and the response per request is a list,
             flatten that list of lists. This is useful when using paging.
             Defaults to False.
@@ -228,9 +230,14 @@ async def up(
     if payloads:
         if isinstance(paths, str):
             paths = [paths]
+        if not isinstance(payloads, list):
+            payloads = [payloads]
         if len(paths) == 1 and len(payloads) > 1:
             logging.info(f"Using path '{paths[0]}' for all {len(payloads)} payloads")
             paths = paths * len(payloads)
+        if len(payloads) == 1 and len(paths) > 1:
+            logging.info(f"Using payload '{payloads[0]}' for all {len(paths)} paths")
+            payloads = payloads * len(paths)
         if len(paths) != len(payloads):
             raise ValueError(
                 f"The number of paths does not match the number of payloads: "


### PR DESCRIPTION
## Description

This PR enables users to make requests to different paths with a single JSON body.

Example:
```python
import asyncio

from unparallel import up


async def main():
    base_url = "http://test.com"
    paths = [f"/post/{i}" for i in range(5)]
    payload = {"foo": "bar"}
    results = await up(base_url, paths, method="post", payloads=payload)


asyncio.run(main())
```

In the case above, we would send the JSON body `{"foo": "bar"}` to all paths.

## Related Issue

Implements #98 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
