### PR TITLE
Feature: Support different URLs per request

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '**'
+
 permissions:
   contents: write
 jobs:

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -95,7 +95,7 @@ async def single_request(
 async def request_urls(
     urls: List[str],
     method: str,
-    base_url: str,
+    base_url: Optional[str] = None,
     headers: Optional[Dict[str, Any]] = None,
     payloads: Optional[Any] = None,
     flatten_result: bool = False,
@@ -109,19 +109,19 @@ async def request_urls(
     via ``asyncio`` and ``httpx``.
 
     Args:
-        urls: A list of URLs for the HTTP requests.
-        method: HTTP method to use, e.g. get, post, etc.
-        base_url: The base URL of the service, e.g. http://localhost:8000.
-        headers: A dictionary of headers to use.
-        payloads: A list of JSON payloads (dictionaries) for e.g. HTTP post requests.
+        urls (List[str]): A list of URLs for the HTTP requests.
+        method (str): HTTP method to use, e.g. get, post, etc.
+        base_url (Optional[str]): The base URL of the service, e.g. http://localhost:8000.
+        headers (Optional[Dict[str, Any]]): A dictionary of headers to use.
+        payloads (Optional[Any]): A list of JSON payloads (dictionaries) for e.g. HTTP post requests.
             Used together with ``urls``.
-        flatten_result: If True and the response per request is a list, flatten that
+        flatten_result (bool): If True and the response per request is a list, flatten that
             list of lists. This is useful when using paging.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
         limits (httpx.Limits): The limits configuration for ``httpx``.
         timeouts (httpx.Timeout): The timeout configuration for ``httpx``.
-        progress: If set to True, progress bar is shown
+        progress (bool): Whether to show a progress bar. Defaults to ``True``.
 
     Returns:
         A list of the response data per request in the same order as the input
@@ -227,10 +227,12 @@ async def up(
             f"Supported methods: {VALID_HTTP_METHODS}"
         )
 
+    # Wrap single URL into list to check for alignment with payload
+    if isinstance(urls, str):
+        urls = [urls]
+
     # Check if payloads align with URLs
     if payloads:
-        if isinstance(urls, str):
-            urls = [urls]
         if not isinstance(payloads, list):
             payloads = [payloads]
         if len(urls) == 1 and len(payloads) > 1:


### PR DESCRIPTION
## Description

This PR enables users to create requests to different URLs in one call to `up()`. This is done by
* renaming the arg `paths` -> `urls`,
* making the arg `base_url` optional, and
* changing the order of the first few args to `up()`: `base_url, paths, method` -> `urls, method, base_url`.

This is a breaking change! 💣 

While you still can use Unparallel to make requests to one service

```python
base_url = "https://httpbin.org"
paths = [f"/get?i={i}" for i in range(5)]
results = await up(paths, base_url=base_url)
```

you can now make requests to various URLs

```python
urls = [
    "https://httpbin.org/get?i=42",
    "https://petstore.swagger.io/v2/pet/findByStatus?status=available",
    "https://api.coindesk.com/v1/bpi/currentprice.json"
]
results = await up(urls)
```

---

Additionally, this PR includes a fix for the docs CI to also run on tags.

## Related Issue
Closes #99 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔖 Release

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
