### PR TITLE
Feature: Add parameter to configure custom response function

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,7 +5,7 @@ This page contains some more advanced and realistic examples of using Unparallel
 --8<-- "docs/examples/wordpress.py"
 ```
 
-This should print something like:
+If you run the example, it should print something like the following:
 ```
 Website 'https://techcrunch.com/wp-json/wp/v2' has 12202 pages (page size = 20)
 Making async requests: 100%|███████████| 1000/1000 [00:13<00:00, 74.30it/s]
@@ -39,4 +39,19 @@ Making async requests: 100%|███████████| 1000/1000 [00:13<
   'title': {'rendered': 'Nonprofit Code.org sues Byju&#8217;s unit WhiteHat Jr '
                         'over payment dues'},
   'author': 133574269}]
+```
+
+## Fetch the content of multiple websites
+```python
+--8<-- "docs/examples/multiple_websites.py"
+```
+
+If you run the example, it should print something like the following:
+```
+Making async requests: 100%|███████████| 43/43 [00:03<00:00, 11.60it/s]
+https://www.google.com/ '<!doctype html><html itemscope="" itemtype="http://schema.org/WebPage" lang="de-AT"><head><meta cont'
+https://www.youtube.com/ '<!DOCTYPE html><html style="font-size: 10px;font-family: Roboto, Arial, sans-serif;" lang="de-DE" da'
+https://www.facebook.com/ '<!DOCTYPE html>\n<html lang="de" id="facebook" class="no_js">\n<head><meta charset="utf-8" /><meta nam'
+https://www.wikipedia.org/ '<!DOCTYPE html>\n<html lang="en" class="no-js">\n<head>\n<meta charset="utf-8">\n<title>Wikipedia</title'
+https://www.instagram.com/ '<!DOCTYPE html><html class="_9dls" lang="en" dir="ltr"><head><link data-default-icon="https://static'
 ```

--- a/docs/examples/multiple_websites.py
+++ b/docs/examples/multiple_websites.py
@@ -1,0 +1,72 @@
+"""
+This script is based on a use case at StackOverflow and fetches the content of various 
+webpages.
+
+See Also:
+    https://stackoverflow.com/a/57129241
+"""
+import asyncio
+from pprint import pp
+
+import httpx
+
+from unparallel import up
+
+websites = """https://google.com/
+https://youtube.com/
+https://facebook.com/
+https://twitter.com/
+https://wikipedia.org/
+https://instagram.com/
+https://reddit.com/
+https://amazon.com/
+https://duckduckgo.com/
+https://yahoo.com/
+https://tiktok.com/
+https://bing.com/
+https://yahoo.co.jp/
+https://weather.com/
+https://whatsapp.com/
+https://yandex.ru/
+https://openai.com/
+https://live.com/
+https://microsoft.com/
+https://microsoftonline.com/
+https://linkedin.com/
+https://quora.com/
+https://twitch.tv/
+https://naver.com/
+https://netflix.com/
+https://office.com/
+https://vk.com/
+https://globo.com/
+https://Aliexpress.com/
+https://cnn.com/
+https://zoom.us/
+https://imdb.com/
+https://x.com/
+https://newyorktimes.com/
+https://onlyfans.com/
+https://espn.com/
+https://amazon.co.jp/
+https://pinterest.com/
+https://uol.com.br/
+https://ebay.com/
+https://marca.com/
+https://canva.com/
+https://spotify.com/
+https://bbc.com/
+https://paypal.com/
+https://apple.com/"""
+
+
+async def main():
+    urls = websites.split("\n")
+
+    # Get all pages
+    results = await up(urls, method="GET", response_fn=lambda x: x.text)
+    for url, content in zip(urls, results[:5]):
+        print(url, content[:100])
+
+
+results = asyncio.run(main())

--- a/docs/examples/multiple_websites.py
+++ b/docs/examples/multiple_websites.py
@@ -3,70 +3,69 @@ This script is based on a use case at StackOverflow and fetches the content of v
 webpages.
 
 See Also:
-    https://stackoverflow.com/a/57129241
+    https://www.stackoverflow.com/a/57129241
 """
 import asyncio
-from pprint import pp
-
-import httpx
 
 from unparallel import up
 
-websites = """https://google.com/
-https://youtube.com/
-https://facebook.com/
-https://twitter.com/
-https://wikipedia.org/
-https://instagram.com/
-https://reddit.com/
-https://amazon.com/
-https://duckduckgo.com/
-https://yahoo.com/
-https://tiktok.com/
-https://bing.com/
-https://yahoo.co.jp/
-https://weather.com/
-https://whatsapp.com/
-https://yandex.ru/
-https://openai.com/
-https://live.com/
-https://microsoft.com/
-https://microsoftonline.com/
-https://linkedin.com/
-https://quora.com/
-https://twitch.tv/
-https://naver.com/
-https://netflix.com/
-https://office.com/
-https://vk.com/
-https://globo.com/
-https://Aliexpress.com/
-https://cnn.com/
-https://zoom.us/
-https://imdb.com/
-https://x.com/
-https://newyorktimes.com/
-https://onlyfans.com/
-https://espn.com/
-https://amazon.co.jp/
-https://pinterest.com/
-https://uol.com.br/
-https://ebay.com/
-https://marca.com/
-https://canva.com/
-https://spotify.com/
-https://bbc.com/
-https://paypal.com/
-https://apple.com/"""
+websites = """https://www.google.com/
+https://www.youtube.com/
+https://www.facebook.com/
+https://www.wikipedia.org/
+https://www.instagram.com/
+https://www.reddit.com/
+https://www.amazon.com/
+https://www.duckduckgo.com/
+https://www.yahoo.com/
+https://www.tiktok.com/
+https://www.bing.com/
+https://www.yahoo.co.jp/
+https://www.weather.com/
+https://www.whatsapp.com/
+https://www.yandex.ru/
+https://www.openai.com/
+https://www.live.com/
+https://www.microsoft.com/
+https://www.linkedin.com/
+https://www.quora.com/
+https://www.twitch.tv/
+https://www.naver.com/
+https://www.netflix.com/
+https://www.office.com/
+https://www.vk.com/
+https://www.globo.com/
+https://www.Aliexpress.com/
+https://www.cnn.com/
+https://www.zoom.us/
+https://www.imdb.com/
+https://www.x.com/
+https://www.nytimes.com/
+https://www.onlyfans.com/
+https://www.espn.com/
+https://www.amazon.co.jp/
+https://www.pinterest.com/
+https://www.uol.com.br/
+https://www.ebay.com/
+https://www.marca.com/
+https://www.canva.com/
+https://www.spotify.com/
+https://www.bbc.com/
+https://www.paypal.com/
+https://www.apple.com/"""
 
 
 async def main():
     urls = websites.split("\n")
 
     # Get all pages
-    results = await up(urls, method="GET", response_fn=lambda x: x.text)
+    results = await up(
+        urls, method="GET", response_fn=lambda x: x.text, raise_for_status=False
+    )
+
+    # Print the content of the first 5 pages
     for url, content in zip(urls, results[:5]):
-        print(url, content[:100])
+        print(url, repr(content[:100]))
 
 
 results = asyncio.run(main())

--- a/docs/examples/multiple_websites.py
+++ b/docs/examples/multiple_websites.py
@@ -8,7 +8,9 @@ See Also:
 import asyncio
 
 from unparallel import up
+from unparallel.unparallel import RequestError
 
+# Extracted from https://en.wikipedia.org/wiki/List_of_most-visited_websites
 websites = """https://www.google.com/
 https://www.youtube.com/
 https://www.facebook.com/
@@ -41,7 +43,6 @@ https://www.zoom.us/
 https://www.imdb.com/
 https://www.x.com/
 https://www.nytimes.com/
-https://www.onlyfans.com/
 https://www.espn.com/
 https://www.amazon.co.jp/
 https://www.pinterest.com/

--- a/docs/examples/wordpress.py
+++ b/docs/examples/wordpress.py
@@ -11,34 +11,44 @@ from pprint import pp
 import httpx
 
 from unparallel import up
+from unparallel.unparallel import RequestError
 
 
 async def main():
     page_size = 20
-    url = "https://techcrunch.com/wp-json/wp/v2"
-    pagination_url = f"{url}/posts?per_page={page_size}"
+    base_url = "https://techcrunch.com/wp-json/wp/v2"
+    pagination_url = f"/posts?per_page={page_size}"
 
     # Get page count
     page_size = 20
-    response = httpx.head(pagination_url)
+    response = httpx.head(base_url + pagination_url)
     total_pages = int(response.headers["X-WP-TotalPages"])
-    print(f"Website '{url}' has {total_pages} pages (page size = {page_size})")
+    print(f"Website '{base_url}' has {total_pages} pages (page size = {page_size})")
 
-    # Comment the line below to get all pages
+    # Comment the line below to get all pages. Note that you will have to adjust
+    # the settings for this to work without errors. For me, it worked using
+    # max_connections=800 and timeout=180
+
     total_pages = min(total_pages, 1000)
 
     # Get all pages and flatten the result
     paths = [f"{pagination_url}&page={i}" for i in range(1, total_pages + 1)]
-    results = await up(url, paths, method="GET", flatten_result=True)
+    results = await up(paths, method="GET", base_url=base_url, flatten_result=True)
+
+    # Check if some requests failed
+    valid_results = [item for item in results if not isinstance(item, RequestError)]
+    fails = len(results) - len(valid_results)
+    print(f"{fails=} ({fails/len(results):.2%})")
 
     # Display some properties of the first 5 posts
     intersting_keys = ["id", "date", "slug", "title", "author"]
     pp(
         [
             {k: v for k, v in item.items() if k in intersting_keys}
-            for item in results[:5]
+            for item in valid_results[:5]
         ]
     )
 
 
-results = asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/wordpress.py
+++ b/docs/examples/wordpress.py
@@ -27,11 +27,18 @@ async def main():
     # Comment the line below to get all pages
     total_pages = min(total_pages, 1000)
 
-    # Get all pages
+    # Get all pages and flatten the result
     paths = [f"{pagination_url}&page={i}" for i in range(1, total_pages + 1)]
-    return await up(url, paths, method="GET", flatten_result=True)
+    results = await up(url, paths, method="GET", flatten_result=True)
+
+    # Display some properties of the first 5 posts
+    intersting_keys = ["id", "date", "slug", "title", "author"]
+    pp(
+        [
+            {k: v for k, v in item.items() if k in intersting_keys}
+            for item in results[:5]
+        ]
+    )
 
 
 results = asyncio.run(main())
-intersting_keys = ["id", "date", "slug", "title", "author"]
-pp([{k: v for k, v in item.items() if k in intersting_keys} for item in results[:5]])

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,7 +22,6 @@ Making async requests: 100%|███████████| 100/100 [00:01<00
 [{'foo': '0'}, {'foo': '1'}, {'foo': '2'}, {'foo': '3'}, {'foo': '4'}]
 ```
 
-
 ## POSTing Data
 ### One body for different paths
 If you want to do POST instead of GET requests, you just have to pass `method='POST'`
@@ -86,15 +85,38 @@ Making async requests: 100%|███████████| 100/100 [00:01<00
  '{"type": "tree", "height": 4}']
 ```
 
-## :construction: Other HTTP methods
+## Custom response functions
 
-!!! warning
 
-    Currently (version `0.1.0`) the method `.json()` is called on every response.
-    Hence, HTTP methods that don't return a JSON body will not work as expected.
-
+## Other HTTP methods
 Besides the popular GET and POST methods, you can use any other HTTP method supported 
 by HTTPX - which are `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIONS`.
+
+For example, you can get the status of services/webpages using the method `HEAD` in
+combination with a custom reponse function:
+
+```python
+import asyncio
+
+from unparallel import up
+
+async def main():
+    urls = [
+        "https://www.example.com",
+        "https://www.ecosia.org",
+        "https://github.com"
+    ]
+    return await up(urls, method="HEAD", response_fn=lambda x: x.status_code)
+
+results = asyncio.run(main())
+print(results)
+```
+
+This prints:
+```
+Making async requests: 100%|███████████| 3/3 [00:00<00:00,  4.43it/s]
+[200, 200, 200]
+```
 
 
 ## Pagination and flattening

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -141,7 +141,7 @@ from unparallel import up
 async def main():
     urls = [
         "https://www.example.com",
-        "https://www.ecosia.org",
+        "https://duckduckgo.com/",
         "https://github.com"
     ]
     return await up(urls, method="HEAD", response_fn=lambda x: x.status_code)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,10 +94,13 @@ For this, define your own response function/callback using a `def` or `lambda` a
 it to `up()` via the keyword `response_fn`. The function will receive a `httpx.Response`
 object as the argument and can return anything.
 
+If you want to process the raw `httpx.Response` later yourself, you can simply set 
+`response_fn=None`.
+
 The example below demonstrates how to use a custom response function to get the `.text`
 of a response:
 
-```python
+```python hl_lines="11"
 import asyncio
 
 from unparallel import up
@@ -115,18 +118,13 @@ for res in results:
     print(repr(res[:50]))
 ```
 
-This prints:
+This should print something similar to the following:
 ```
 Making async requests: 100%|███████████| 3/3 [00:00<00:00,  4.43it/s]
 '<!doctype html>\n<html>\n<head>\n    <title>Example D'
 '<!DOCTYPE html><html lang="en-US"><head><meta char'
 '\n\n\n\n\n\n<!DOCTYPE html>\n<html\n  lang="en"\n  \n  \n  da'
 ```
-(Or something similar if the website was changed.)
-
-
-If you want to process the raw `httpx.Response` later yourself, you can simply set 
-`response_fn=None`.
 
 ## Other HTTP methods
 Besides the popular GET and POST methods, you can use any other HTTP method supported 
@@ -135,7 +133,7 @@ by HTTPX - which are `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIO
 For example, you can get the status of services/webpages using the method `HEAD` in
 combination with a custom response function:
 
-```python
+```python hl_lines="11"
 import asyncio
 
 from unparallel import up

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,7 +93,7 @@ Besides the popular GET and POST methods, you can use any other HTTP method supp
 by HTTPX - which are `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIONS`.
 
 For example, you can get the status of services/webpages using the method `HEAD` in
-combination with a custom reponse function:
+combination with a custom response function:
 
 ```python
 import asyncio

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,47 @@ Making async requests: 100%|███████████| 100/100 [00:01<00
 ```
 
 ## Custom response functions
+Per default, Unparallel will call the `.json()` function on every `httpx.Response` and 
+return the result. But you might want to get other data from the response like the 
+content as plain-text or the HTTP status. 
 
+For this, define your own response function/callback using a `def` or `lambda` and pass
+it to `up()` via the keyword `response_fn`. The function will receive a `httpx.Response`
+object as the argument and can return anything.
+
+The example below demonstrates how to use a custom response function to get the `.text`
+of a response:
+
+```python
+import asyncio
+
+from unparallel import up
+
+async def main():
+    urls = [
+        "https://www.example.com",
+        "https://duckduckgo.com/",
+        "https://github.com"
+    ]
+    return await up(urls, response_fn=lambda x: x.text)
+
+results = asyncio.run(main())
+for res in results:
+    print(repr(res[:50]))
+```
+
+This prints:
+```
+Making async requests: 100%|███████████| 3/3 [00:00<00:00,  4.43it/s]
+'<!doctype html>\n<html>\n<head>\n    <title>Example D'
+'<!DOCTYPE html><html lang="en-US"><head><meta char'
+'\n\n\n\n\n\n<!DOCTYPE html>\n<html\n  lang="en"\n  \n  \n  da'
+```
+(Or something similar if the website was changed.)
+
+
+If you want to process the raw `httpx.Response` later yourself, you can simply set 
+`response_fn=None`.
 
 ## Other HTTP methods
 Besides the popular GET and POST methods, you can use any other HTTP method supported 

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -206,10 +206,10 @@ async def up(
             for HTTP post requests. Used together with ``urls``. If one payload but
             multiple URLs are supplied, that payload is used for all requests.
             Defaults to None.
-        response_fn (Optional[Callable[[httpx.Response], Any]]): The function to apply on every
-            response of the HTTP requests. This can be an existing function of
-            ``httpx.Response`` like ``.json()`` or ``.read()``, or a custom function
-            which takes the ``httpx.Response`` as argument and can return anything.
+        response_fn (Optional[Callable[[httpx.Response], Any]]): The function (callback)
+            to apply on every response of the HTTP requests. This can be an existing
+            function of ``httpx.Response`` like ``.json()`` or ``.read()``, or a custom
+            function which takes the ``httpx.Response`` as the argument returns ``Any``.
             If you set this to ``None``, you will get the raw ``httpx.Response``.
             Defaults to ``httpx.Response.json``.
         flatten_result (bool): If True and the response per request is a list,

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -176,7 +176,11 @@ async def request_urls(
 
     results = sort_by_idx(results)
     if flatten_result:
-        return [item for sublist in results for item in sublist]
+        return [
+            item
+            for sublist in results
+            for item in ((sublist,) if isinstance(sublist, RequestError) else sublist)
+        ]
     return results
 
 

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -48,6 +48,7 @@ async def single_request(
     json: Optional[Any] = None,
     response_fn: Optional[Callable[[httpx.Response], Any]] = DEFAULT_JSON_FN,
     max_retries_on_timeout: int = 3,
+    raise_for_status: bool = True,
 ) -> Tuple[int, Any]:
     """Do a single web request for the given URL, HTTP method, and playload.
 
@@ -61,6 +62,8 @@ async def single_request(
             on every response of the HTTP requests. Defaults to ``httpx.Response.json``.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
+        raise_for_status (bool): If True, ``.raise_for_status()`` is called on the
+            response.
 
     Returns:
         Tuple[int, Any]: A tuple of the index and the JSON response.
@@ -70,7 +73,8 @@ async def single_request(
     for trial in range(1, max_retries_on_timeout + 1):
         try:
             response = await client.request(method, url, json=json)
-            response.raise_for_status()
+            if raise_for_status:
+                response.raise_for_status()
             if response_fn is None:
                 return idx, response
             result = response_fn(response)
@@ -107,6 +111,7 @@ async def request_urls(
     response_fn: Optional[Callable[[httpx.Response], Any]] = DEFAULT_JSON_FN,
     flatten_result: bool = False,
     max_retries_on_timeout: int = 3,
+    raise_for_status: bool = True,
     limits: httpx.Limits = DEFAULT_LIMITS,
     timeouts: httpx.Timeout = DEFAULT_TIMEOUT,
     progress: bool = True,
@@ -126,6 +131,8 @@ async def request_urls(
             on every response of the HTTP requests. Defaults to ``httpx.Response.json``.
         flatten_result (bool): If True and the response per request is a list, flatten
             that list of lists. This is useful when using paging.
+        raise_for_status (bool): If True, ``.raise_for_status()`` is called on every
+            response.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
         limits (httpx.Limits): The limits configuration for ``httpx``.
@@ -156,6 +163,7 @@ async def request_urls(
                     json=payloads[i] if payloads else None,
                     response_fn=response_fn,
                     max_retries_on_timeout=max_retries_on_timeout,
+                    raise_for_status=raise_for_status,
                 )
             )
             tasks.append(task)
@@ -183,6 +191,7 @@ async def up(
     max_connections: Optional[int] = 100,
     timeout: Optional[int] = 10,
     max_retries_on_timeout: int = 3,
+    raise_for_status: bool = True,
     limits: Optional[httpx.Limits] = None,
     timeouts: Optional[httpx.Timeout] = None,
     progress: bool = True,
@@ -221,6 +230,8 @@ async def up(
             This is passed into ``httpx.Timeout``.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
+        raise_for_status (bool): If True, ``.raise_for_status()`` is called on overy
+            response.
         limits (Optional[httpx.Limits]): The limits configuration for ``httpx``.
             If specified, this overrides the ``max_connections`` parameter.
         timeouts (Optional[httpx.Timeout]): The timeout configuration for ``httpx``.
@@ -282,6 +293,7 @@ async def up(
         response_fn=response_fn,
         flatten_result=flatten_result,
         max_retries_on_timeout=max_retries_on_timeout,
+        raise_for_status=raise_for_status,
         progress=progress,
         limits=limits,
         timeouts=timeouts,

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import httpx
 from tqdm.asyncio import tqdm as tqdm_async
@@ -9,6 +9,7 @@ from tqdm.asyncio import tqdm as tqdm_async
 logger = logging.getLogger(__name__)
 VALID_HTTP_METHODS = ("GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS")
 
+DEFAULT_JSON_FN = httpx.Response.json
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=10)
 DEFAULT_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
 
@@ -45,6 +46,7 @@ async def single_request(
     url: str,
     method: str,
     json: Optional[Any] = None,
+    response_fn: Optional[Callable[[httpx.Response], Any]] = DEFAULT_JSON_FN,
     max_retries_on_timeout: int = 3,
 ) -> Tuple[int, Any]:
     """Do a single web request for the given URL, HTTP method, and playload.
@@ -55,6 +57,8 @@ async def single_request(
         url (str): The URL after the base URI.
         method (str): The HTTP method.
         json (Optional[Any], optional): The JSON payload. Defaults to None.
+        response_fn (Optional[Callable[[httpx.Response], Any]]): The function to apply
+            on every response of the HTTP requests. Defaults to ``httpx.Response.json``.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
 
@@ -67,8 +71,10 @@ async def single_request(
         try:
             response = await client.request(method, url, json=json)
             response.raise_for_status()
-            json_data = response.json()
-            return idx, json_data
+            if response_fn is None:
+                return idx, response
+            result = response_fn(response)
+            return idx, result
         except httpx.TimeoutException as timeout_ex:
             exception = timeout_ex
             await asyncio.sleep(1)
@@ -98,6 +104,7 @@ async def request_urls(
     base_url: Optional[str] = None,
     headers: Optional[Dict[str, Any]] = None,
     payloads: Optional[Any] = None,
+    response_fn: Optional[Callable[[httpx.Response], Any]] = DEFAULT_JSON_FN,
     flatten_result: bool = False,
     max_retries_on_timeout: int = 3,
     limits: httpx.Limits = DEFAULT_LIMITS,
@@ -113,10 +120,12 @@ async def request_urls(
         method (str): HTTP method to use, e.g. get, post, etc.
         base_url (Optional[str]): The base URL of the service, e.g. http://localhost:8000.
         headers (Optional[Dict[str, Any]]): A dictionary of headers to use.
-        payloads (Optional[Any]): A list of JSON payloads (dictionaries) for e.g. HTTP post requests.
-            Used together with ``urls``.
-        flatten_result (bool): If True and the response per request is a list, flatten that
-            list of lists. This is useful when using paging.
+        payloads (Optional[Any]): A list of JSON payloads (dictionaries) for e.g. HTTP
+            post requests. Used together with ``urls``.
+        response_fn (Optional[Callable[[httpx.Response], Any]]): The function to apply
+            on every response of the HTTP requests. Defaults to ``httpx.Response.json``.
+        flatten_result (bool): If True and the response per request is a list, flatten
+            that list of lists. This is useful when using paging.
         max_retries_on_timeout (int): The maximum number retries if the requests fails
             due to a timeout (``httpx.TimeoutException``). Defauls to 3.
         limits (httpx.Limits): The limits configuration for ``httpx``.
@@ -145,6 +154,7 @@ async def request_urls(
                     client=client,
                     method=method,
                     json=payloads[i] if payloads else None,
+                    response_fn=response_fn,
                     max_retries_on_timeout=max_retries_on_timeout,
                 )
             )
@@ -168,6 +178,7 @@ async def up(
     base_url: Optional[str] = None,
     headers: Optional[Dict[str, Any]] = None,
     payloads: Optional[Any] = None,
+    response_fn: Optional[Callable[[httpx.Response], Any]] = DEFAULT_JSON_FN,
     flatten_result: bool = False,
     max_connections: Optional[int] = 100,
     timeout: Optional[int] = 10,
@@ -195,6 +206,12 @@ async def up(
             for HTTP post requests. Used together with ``urls``. If one payload but
             multiple URLs are supplied, that payload is used for all requests.
             Defaults to None.
+        response_fn (Optional[Callable[[httpx.Response], Any]]): The function to apply on every
+            response of the HTTP requests. This can be an existing function of
+            ``httpx.Response`` like ``.json()`` or ``.read()``, or a custom function
+            which takes the ``httpx.Response`` as argument and can return anything.
+            If you set this to ``None``, you will get the raw ``httpx.Response``.
+            Defaults to ``httpx.Response.json``.
         flatten_result (bool): If True and the response per request is a list,
             flatten that list of lists. This is useful when using paging.
             Defaults to False.
@@ -262,6 +279,7 @@ async def up(
         base_url=base_url,
         headers=headers,
         payloads=payloads,
+        response_fn=response_fn,
         flatten_result=flatten_result,
         max_retries_on_timeout=max_retries_on_timeout,
         progress=progress,


### PR DESCRIPTION
## Description

This PR adds the feature of defining custom response functions to process the response, i.e. callbacks. This means that the user can decide what to do with the response.

A simple example might be getting the HTTP status codes for a bunch of URLs:

```python
import asyncio

from unparallel import up

async def main():
    urls = [
        "https://www.example.com",
        "https://duckduckgo.com/",
        "https://github.com"
    ]
    return await up(urls, method="HEAD", response_fn=lambda x: x.status_code)

results = asyncio.run(main())
print(results)
```

This prints:
```
Making async requests: 100%|███████████| 3/3 [00:00<00:00,  4.43it/s]
[200, 200, 200]
```

**Main Changes:**
* ✨ Add parameter to configure custom response function
* ✅ Add corresponding tests
* 📝 Add documentation about custom response callback

**Additional Changes:**
* ✨ Add option to disable raising for status
* 🐛 Fix flatten results if there are errors
* ♻️ Refactor script for wordpress
* ♻️ Refactor example for mulitple websites
* 📝 Extends usage docs with section about "other HTTP methods"
* 📝 Add example for requesting multiple websites

## Related Issue

Closes #100 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔖 Release

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
