### PR TITLE
Change: Mitigate timeouts by adding Semaphore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/docs/examples/wordpress.py
+++ b/docs/examples/wordpress.py
@@ -25,9 +25,9 @@ async def main():
     total_pages = int(response.headers["X-WP-TotalPages"])
     print(f"Website '{base_url}' has {total_pages} pages (page size = {page_size})")
 
-    # Comment the line below to get all pages. Note that you will have to adjust
+    # Comment the line below to get all pages. Note that you might have to adjust
     # the settings for this to work without errors. For me, it worked using
-    # max_connections=800 and timeout=180
+    # max_connections=800 and timeout=60.
 
     total_pages = min(total_pages, 1000)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ color_output = true
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file
-python_version = 3.8
+python_version = "3.8"
 pretty = true
 show_traceback = true
 color_output = true

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -7,6 +7,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import httpx
 from tqdm.asyncio import tqdm as tqdm_async
 
+from unparallel.utils import AsyncNullContext
+
 logger = logging.getLogger(__name__)
 
 VALID_HTTP_METHODS = ("GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS")
@@ -82,7 +84,7 @@ async def single_request(
             await asyncio.sleep(1)
 
         try:
-            async with semaphore or contextlib.nullcontext():  # type: ignore
+            async with semaphore or AsyncNullContext():
                 response = await client.request(method, url, json=json)
             if raise_for_status:
                 response.raise_for_status()

--- a/unparallel/unparallel.py
+++ b/unparallel/unparallel.py
@@ -7,11 +7,14 @@ import httpx
 from tqdm.asyncio import tqdm as tqdm_async
 
 logger = logging.getLogger(__name__)
+
 VALID_HTTP_METHODS = ("GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS")
 
 DEFAULT_JSON_FN = httpx.Response.json
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=10)
 DEFAULT_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+
+SEMAPHORE_COUNT = 1000
 
 
 @dataclass
@@ -70,7 +73,10 @@ async def single_request(
     """
     trial = 0
     exception: Optional[Exception] = None
-    for trial in range(1, max_retries_on_timeout + 1):
+    for trial in range(max(0, max_retries_on_timeout) + 1):
+        if trial > 0:
+            await asyncio.sleep(1)
+
         try:
             response = await client.request(method, url, json=json)
             if raise_for_status:
@@ -79,9 +85,8 @@ async def single_request(
                 return idx, response
             result = response_fn(response)
             return idx, result
-        except httpx.TimeoutException as timeout_ex:
-            exception = timeout_ex
-            await asyncio.sleep(1)
+        except (httpx.TimeoutException, httpx.NetworkError) as retry_ex:
+            exception = retry_ex
         except Exception as ex:  # pylint: disable=broad-except
             exception = ex
             break
@@ -89,7 +94,7 @@ async def single_request(
     # this assert is here to make mypy happy
     assert exception is not None
     logger.warning(
-        f"{exception.__class__.__name__} was raised after {trial} tries: {exception}"
+        f"{exception.__class__.__name__} was raised after {trial+1} tries: {exception}"
     )
     return (
         idx,
@@ -100,6 +105,12 @@ async def single_request(
             exception=exception,
         ),
     )
+
+
+async def bound_fetch(sem: asyncio.Semaphore, *args, **kwargs):
+    """This function synchronizes ``single_request`` with a semaphore object."""
+    async with sem:
+        return await single_request(*args, **kwargs)
 
 
 async def request_urls(
@@ -145,6 +156,11 @@ async def request_urls(
     """
     tasks = []
     results = []
+    # If you want to do lot's of web requests (over 10k), it is really hard to avoid
+    # getting timeout errors. Adding a semaphore with a limit of 1k drastically reduced
+    # the amount of timeouts. As one will likely use fewer parallel open connections
+    # (max_connections) than 1k, it should not slow down the HTTP requests.
+    semaphore = asyncio.Semaphore(SEMAPHORE_COUNT)
 
     logging.debug(
         f"Issuing {len(urls)} {method.upper()} request(s) to base URL '{base_url}' "
@@ -155,7 +171,8 @@ async def request_urls(
     ) as client:
         for i, url in enumerate(urls):
             task = asyncio.create_task(
-                single_request(
+                bound_fetch(
+                    semaphore,
                     idx=i,
                     url=url,
                     client=client,

--- a/unparallel/utils.py
+++ b/unparallel/utils.py
@@ -1,0 +1,12 @@
+import contextlib
+
+
+class AsyncNullContext(contextlib.AbstractAsyncContextManager[None]):
+    """A nullcontext including __aenter__ and __aexit__ to support Python versions
+    below 3.10."""
+
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, *excinfo):
+        pass

--- a/unparallel/utils.py
+++ b/unparallel/utils.py
@@ -1,7 +1,4 @@
-import contextlib
-
-
-class AsyncNullContext(contextlib.AbstractAsyncContextManager[None]):
+class AsyncNullContext:
     """A nullcontext including __aenter__ and __aexit__ to support Python versions
     below 3.10."""
 


### PR DESCRIPTION
## Description
This PR adds a semaphore object to synchronize the web requests with a default value of 1000 (magic number). The intuition behind that is if you do a ton of web requests, all async tasks + TCP requests are created immediately and their "timer" is started. If we restrict the number of parallel web requests, they can wait until others are completed without timing out. 

I chose 1000 for the semaphore because it is unlikely that HTTPX will open more than 1k TCP connections and therefore this should not slow down HTTPX.

## Related Issue
n/a

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔖 Release

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
