### PR TITLE
Refactor tests and mock URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ I created this project with [python-package-template](https://github.com/TezRoma
 
 <!-- --8<-- [end:index] -->
 
-[docs-usage]: https://rafaelwo.github.io/unparallel/usage/
+[docs-usage]: https://rafaelwo.github.io/unparallel/latest/usage/
 [sync-async-gif]: https://raw.githubusercontent.com/RafaelWO/unparallel/main/docs/assets/sync-vs-async.gif
 [contrib]: https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,7 +113,11 @@ from unparallel import up
 
 
 async def main():
-    urls = ["https://www.example.com", "https://duckduckgo.com/", "https://github.com"]
+    urls = [
+        "https://www.example.com",
+        "https://duckduckgo.com/",
+        "https://github.com",
+    ]
     return await up(urls, response_fn=lambda x: x.text)
 
 
@@ -144,7 +148,11 @@ from unparallel import up
 
 
 async def main():
-    urls = ["https://www.example.com", "https://duckduckgo.com/", "https://github.com"]
+    urls = [
+        "https://www.example.com",
+        "https://duckduckgo.com/",
+        "https://github.com",
+    ]
     return await up(urls, method="HEAD", response_fn=lambda x: x.status_code)
 
 

--- a/tests/test_code_in_markdown.py
+++ b/tests/test_code_in_markdown.py
@@ -1,8 +1,10 @@
+import re
+
 import pytest
 from pytest_examples import CodeExample, EvalExample, find_examples
 
 
-def skip_check(example: CodeExample):
+def check_for_skip(example: CodeExample):
     """Checks whether a code block is declared to be skipped via a comment above."""
     with open(example.path) as file:
         for i, line in enumerate(file):
@@ -11,16 +13,24 @@ def skip_check(example: CodeExample):
                     pytest.skip("Found 'skip-test' above source code")
 
 
+def limit_requests(example: CodeExample, num_requests: int = 3):
+    """Change the example's source code to only make `num_requests` requests."""
+    example.source = re.sub(
+        r"range\([\d, ]+\)", f"range({num_requests})", example.source
+    )
+
+
 @pytest.mark.parametrize("example", find_examples("README.md"), ids=str)
 def test_readme(example: CodeExample, eval_example: EvalExample):
-    skip_check(example)
+    check_for_skip(example)
+    limit_requests(example)
     eval_example.lint(example)
     eval_example.run(example)
 
 
 @pytest.mark.parametrize("example", find_examples("docs/usage.md"), ids=str)
 def test_docs_usage(example: CodeExample, eval_example: EvalExample):
-    find_examples("docs/examples/")
-    skip_check(example)
+    check_for_skip(example)
+    limit_requests(example)
     eval_example.lint(example)
     eval_example.run(example)

--- a/tests/test_code_in_markdown.py
+++ b/tests/test_code_in_markdown.py
@@ -1,6 +1,9 @@
 import re
+import urllib.parse
 
 import pytest
+import respx
+from httpx import Response
 from pytest_examples import CodeExample, EvalExample, find_examples
 
 
@@ -20,17 +23,41 @@ def limit_requests(example: CodeExample, num_requests: int = 3):
     )
 
 
+def mock_urls(example: CodeExample):
+    """Finds URLs in code examples and mocks them so that the tests don't rely on the
+    live-service.
+    """
+    for url in re.findall(r"\"http.+?\"", example.source):
+        url = url.strip('"')
+        host = urllib.parse.urlsplit(url).hostname
+        response = "mocked"
+        if "httpbin" in url:
+            response = {"args": 42, "data": {"foo": "bar"}}
+        elif "universities.hipolabs" in url:
+            response = [{"page": 1}, {"page": 2}]
+        route = respx.route(host=host, method__in=["GET", "POST", "HEAD"])
+        route.return_value = Response(200, json=response)
+
+
+@respx.mock
 @pytest.mark.parametrize("example", find_examples("README.md"), ids=str)
 def test_readme(example: CodeExample, eval_example: EvalExample):
     check_for_skip(example)
-    limit_requests(example)
+    mock_urls(example)
+
+    eval_example.set_config(line_length=80)
     eval_example.lint(example)
+
     eval_example.run(example)
 
 
+@respx.mock
 @pytest.mark.parametrize("example", find_examples("docs/usage.md"), ids=str)
 def test_docs_usage(example: CodeExample, eval_example: EvalExample):
     check_for_skip(example)
-    limit_requests(example)
+    mock_urls(example)
+
+    eval_example.set_config(line_length=80)
     eval_example.lint(example)
+
     eval_example.run(example)


### PR DESCRIPTION
## Description
This PR fixes the issue of errors in the test suite while testing the code snippets in the docs. Since I used real services/APIs in the examples, the tests relied on them being up and healthy but sometimes they were not reachable (see e.g. [this job](https://github.com/RafaelWO/unparallel/actions/runs/8828187966/job/24236697612#step:8:46))

This PR introduces a logic to find the URLs in the examples and mock them so that we don't rely on the real services.

### Changes
* ✅ Mock hosts in tests and limit max requests in example tests
* ✅ Fix tests of code snippets by mocking all URLs
  * Limit line length of code snippets to 80
* 📝 Fix link to docs

## Related Issue

N/A

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔖 Release

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
