### PR TITLE
Feature: Custom HTTPX Client

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -106,7 +106,7 @@ If you want to process the raw `httpx.Response` later yourself, you can simply s
 The example below demonstrates how to use a custom response function to get the `.text`
 of a response:
 
-```python hl_lines="11"
+```python hl_lines="12"
 import asyncio
 
 from unparallel import up
@@ -141,7 +141,7 @@ by HTTPX - which are `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIO
 For example, you can get the status of services/webpages using the method `HEAD` in
 combination with a custom response function:
 
-```python hl_lines="11"
+```python hl_lines="12"
 import asyncio
 
 from unparallel import up
@@ -229,7 +229,7 @@ But in most cases, you would want just one list of all objects (universities), i
 flattened array. Unparallel will flatten the data for you if you pass
 `flatten_result=True`.
 
-```python hl_lines="9"
+```python hl_lines="10"
 import asyncio
 from pprint import pp
 
@@ -308,6 +308,46 @@ results = await up(
     limits=httpx.Limits(max_connections=20, ...),
     timeouts=httpx.Timeout(connect=5, ...)
 )
+```
+
+## Custom client
+If you want full control over the HTTPX client or use advanced configuration options,
+e.g. [authentication](https://www.python-httpx.org/advanced/authentication/) or
+[proxies](https://www.python-httpx.org/advanced/proxies/), you can configure it outside
+and simply pass the `httpx.AsyncClient` instance to Unparallel.
+
+```python
+import asyncio
+
+import httpx
+
+from unparallel import up
+
+
+async def main():
+    url = "https://httpbin.org"
+    paths = [f"/get?foo={i}" for i in range(20)]
+
+    auth = httpx.BasicAuth(username="username", password="secret")
+    async with httpx.AsyncClient(base_url=url, auth=auth) as client:
+        results = await up(paths, client=client)
+    return results
+
+
+results = asyncio.run(main())
+for item in results[:5]:
+    for h_key, h_value in item["headers"].items():
+        if h_key == "Authorization":
+            print(f"Args = {item['args']}, Auth = {h_key}: {h_value}'")
+```
+
+This prints:
+```
+Args = {'foo': '0'}, Auth = Authorization: Basic dXNlcm5hbWU6c2VjcmV0'
+Args = {'foo': '1'}, Auth = Authorization: Basic dXNlcm5hbWU6c2VjcmV0'
+Args = {'foo': '2'}, Auth = Authorization: Basic dXNlcm5hbWU6c2VjcmV0'
+Args = {'foo': '3'}, Auth = Authorization: Basic dXNlcm5hbWU6c2VjcmV0'
+Args = {'foo': '4'}, Auth = Authorization: Basic dXNlcm5hbWU6c2VjcmV0'
 ```
 
 ## Retries

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ plugins:
       handlers:
         python:
           options:
+            docstring_section_style: spacy
             show_root_heading: true
             members_order: source
             show_root_members_full_path: true

--- a/tests/test_code_in_markdown.py
+++ b/tests/test_code_in_markdown.py
@@ -32,7 +32,14 @@ def mock_urls(example: CodeExample):
         host = urllib.parse.urlsplit(url).hostname
         response = "mocked"
         if "httpbin" in url:
-            response = {"args": 42, "data": {"foo": "bar"}}
+            response = {
+                "args": 42,
+                "data": {"foo": "bar"},
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic qpowe3jioqoni2q1",
+                },
+            }
         elif "universities.hipolabs" in url:
             response = [{"page": 1}, {"page": 2}]
         route = respx.route(host=host, method__in=["GET", "POST", "HEAD"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+import httpx
+import pytest
+
+from unparallel.unparallel import DEFAULT_LIMITS, DEFAULT_TIMEOUT
+from unparallel.utils import (
+    httpx_client,
+    sort_by_idx,
+)
+
+BASE_URL = "http://test.com"
+
+
+def test_order_by_idx():
+    to_sort = [(4, "d"), (1, "a"), (3, "c"), (2, "b")]
+    expected = list("abcd")
+    assert sort_by_idx(to_sort) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "client, headers",
+    [
+        (None, {"other": "client"}),
+        (httpx.AsyncClient(headers={"my": "client"}), {"my": "client"}),
+    ],
+)
+async def test_httpx_client(client, headers, respx_mock):
+    route = respx_mock.get(BASE_URL, headers=headers)
+
+    async with httpx_client(
+        "", DEFAULT_LIMITS, DEFAULT_TIMEOUT, headers={"other": "client"}, client=client
+    ) as client_:
+        resp = await client_.get(BASE_URL)
+        print(resp)
+
+    route.calls.assert_called_once()

--- a/unparallel/utils.py
+++ b/unparallel/utils.py
@@ -1,5 +1,8 @@
+from contextlib import asynccontextmanager
 from types import TracebackType
-from typing import Any, Type
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Type
+
+import httpx
 
 
 class AsyncNullContext:
@@ -13,3 +16,32 @@ class AsyncNullContext:
         self, exc_type: Type[Exception], exc_value: Any, traceback: TracebackType
     ) -> None:
         pass
+
+
+@asynccontextmanager
+async def httpx_client(
+    base_url: str,
+    limits: httpx.Limits,
+    timeouts: httpx.Timeout,
+    headers: Optional[Dict[str, Any]] = None,
+    client: Optional[httpx.AsyncClient] = None,
+) -> AsyncIterator[httpx.AsyncClient]:
+    if client is not None:
+        yield client
+    else:
+        async with httpx.AsyncClient(
+            base_url=base_url or "", headers=headers, timeout=timeouts, limits=limits
+        ) as client:
+            yield client
+
+
+def sort_by_idx(results: List[Tuple[int, Any]]) -> List[Any]:
+    """Sorts a list of tuples (index, value) by the index and return just the values.
+
+    Args:
+        results (List[Tuple[int, Any]]): A list of tuples (index, value) to be sorted.
+
+    Returns:
+        List[Any]: The values as a list.
+    """
+    return [item[1] for item in sorted(results, key=lambda x: x[0])]


### PR DESCRIPTION
## Description
This PR adds the feature of having full control over the HTTPX client. You can now pass an instance of `httpx.AsyncClient` to `up()`.

```python
auth = httpx.BasicAuth(username="username", password="secret")
async with httpx.AsyncClient(base_url=url, auth=auth) as client:
    results = await up(paths, client=client)
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔖 Release

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/RafaelWO/unparallel/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/RafaelWO/unparallel/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
